### PR TITLE
Fix/#102 end date as ts

### DIFF
--- a/src/gcp/firestore.py
+++ b/src/gcp/firestore.py
@@ -24,11 +24,11 @@ class FirestoreInterface:
         for video_id in video_ids:
             if video_id not in self.existing_video_ids:
                 doc_ref = collection_ref.document(f"video_{video_id}")
-                doc_ref.set({"id": video_id, "processed_at": processed_at, "end_date": end_date.isoformat()})  # type: ignore
+                doc_ref.set({"id": video_id, "processed_at": processed_at, "end_date": end_date})  # type: ignore
 
     def get_process_video_ids(self, collection_name: str, processed_at: datetime) -> list[str]:
         collection_ref = self._get_collection(collection_name)
-        query = collection_ref.where("end_date", ">=", processed_at.isoformat())  # type: ignore
+        query = collection_ref.where("end_date", ">=", processed_at)  # type: ignore
         docs = query.stream()
         video_ids: list[str] = [doc.to_dict()["id"] for doc in docs]  # type: ignore
         return video_ids

--- a/src/utils/extract_most_popular.py
+++ b/src/utils/extract_most_popular.py
@@ -9,26 +9,24 @@ def extract_published(published_at: str) -> str:
     return f"{date} {time}:00"
 
 
-def extract_most_popular(
-    data: YouTubeVideoResponse, created_at: str
-) -> list[dict[str, Any]]:
+def extract_most_popular(data: YouTubeVideoResponse, created_at: str) -> list[dict[str, Any]]:
     videos_dict = [
         {
             "VIDEO_ID": item["id"],
-            "TITLE": item["snippet"]["title"],
-            "CHANNEL_ID": item["snippet"]["channelId"],
-            "CHANNEL_TITLE": item["snippet"]["channelTitle"],
-            "PUBLISHED_AT": extract_published(item["snippet"]["publishedAt"]),
+            "TITLE": item["snippet"]["title"] if item["snippet"] else "",
+            "CHANNEL_ID": item["snippet"]["channelId"] if item["snippet"] else "",
+            "CHANNEL_TITLE": item["snippet"]["channelTitle"] if item["snippet"] else "",
+            "PUBLISHED_AT": extract_published(item["snippet"]["publishedAt"] if item["snippet"] else ""),
             "CREATED_AT": created_at,
-            "TAGS": item["snippet"].get("tags", []),
-            "CATEGORY_ID": item["snippet"]["categoryId"],
+            "TAGS": item["snippet"].get("tags", []) if item["snippet"] else "",
+            "CATEGORY_ID": item["snippet"]["categoryId"] if item["snippet"] else "",
             # 動画の長さ(P:YMWD, T:HMS)
-            "DURATION": item["contentDetails"]["duration"],
-            "VIEW_COUNT": int(item["statistics"].get("viewCount", 0)),
-            "LIKE_COUNT": int(item["statistics"].get("likeCount", 0)),
-            "DISLIKE_COUNT": int(item["statistics"].get("dislikeCount", 0)),
-            "FAVORITE_COUNT": int(item["statistics"].get("favoriteCount", 0)),
-            "COMMENT_COUNT": int(item["statistics"].get("commentCount", 0)),
+            "DURATION": item["contentDetails"]["duration"] if item["contentDetails"] else "",
+            "VIEW_COUNT": int(item["statistics"].get("viewCount", 0)) if item["statistics"] else None,
+            "LIKE_COUNT": int(item["statistics"].get("likeCount", 0)) if item["statistics"] else None,
+            "DISLIKE_COUNT": int(item["statistics"].get("dislikeCount", 0)) if item["statistics"] else None,
+            "FAVORITE_COUNT": int(item["statistics"].get("favoriteCount", 0)) if item["statistics"] else None,
+            "COMMENT_COUNT": int(item["statistics"].get("commentCount", 0)) if item["statistics"] else None,
         }
         for item in data["items"]
     ]


### PR DESCRIPTION
#102

## 修正点
- end_dateをtimestamp型でfirestoreに保存できるようにする
  - TTLによって削除をする際にtimestamp型でないと削除ができないため
- extract_most_popular関数にtype guardを実装
  - YoutubeVideoItemsのデータ型にOptionalを追加したことで指定したキーがNoneとなってしまう可能性あり。
  - そのため、type guardを実装し指定したキーがない場合は空文字やNoneとする初期値を指定