### PR TITLE
Fix/#108 split request to yt

### DIFF
--- a/src/api/jobs/store.py
+++ b/src/api/jobs/store.py
@@ -51,15 +51,16 @@ def get_video_ids_by_time_window(prefix: PrefixUnit, processed_at: datetime, vid
 
 
 def push_to_pubsub(prefix: PrefixUnit, process_video_ids: list[str]) -> None:
-    ids = ",".join(process_video_ids)
-    part = ",".join(["snippet", "contentDetails", "statistics"])
-
     pubsub = PubSubInterface(project_id=PROJECT_ID, topic_name=TOPIC_NAME)
-    filter_params = VideoFilterParams(ids=ids)
-    video_params = VideosParams(prefix=prefix, part=part, filter=filter_params, maxResults=50)
-    request = InvokeRequest(action=ActionUnit.transfer, params=video_params)
+    part = ",".join(["snippet", "contentDetails", "statistics"])
+    for i in range(0, len(process_video_ids), 50):
+        target_ids = process_video_ids[i : i + 50]
+        ids = ",".join(target_ids)
+        filter_params = VideoFilterParams(ids=ids)
+        video_params = VideosParams(prefix=prefix, part=part, filter=filter_params, maxResults=50)
+        request = InvokeRequest(action=ActionUnit.transfer, params=video_params)
 
-    pubsub.publish(request.model_dump_json())
+        pubsub.publish(request.model_dump_json())
 
 
 async def store(params: VideosParams) -> ResponseMessage:

--- a/src/youtube/youtube_api.py
+++ b/src/youtube/youtube_api.py
@@ -17,10 +17,11 @@ class YoutubeApiRequest:
         youtube_api_version: str,
         developer_key: str,
     ) -> None:
-        self.youtube: object = build(youtube_api_service_name, youtube_api_version, developerKey=developer_key)
+        self.youtube: object = build(
+            serviceName=youtube_api_service_name, version=youtube_api_version, developerKey=developer_key
+        )
         jst: BaseTzInfo = pytz.timezone("Asia/Tokyo")
         self.processed_at: datetime = datetime.now(jst)
-        # self.processed_date = dt.strftime("%Y%m%d%H%M")
 
     def get_most_popular(self, part: str, chart: str, maxResults: int) -> YouTubeVideoResponse:
         request = self.youtube.videos().list(  # type: ignore


### PR DESCRIPTION
#108 

## 修正点
- リクエストに含めるidを50個単位で分割
- pubsubに50個ずつidをpush → CloudRunで並列処理