### PR TITLE
fix: ENV legacy format in Dockerfile.prd

### DIFF
--- a/src/Dockerfile.prd
+++ b/src/Dockerfile.prd
@@ -31,7 +31,7 @@ COPY --from=builder /usr/local/bin/ /usr/local/bin/
 # アプリケーションのコードをコピー
 COPY ./src ./
 
-ENV PORT 8080
+ENV PORT=8080
 
 # アプリケーションの実行
 CMD ["uvicorn", "main:app", "--workers", "2", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
#111 
## 修正点
- Dockerfile.prdのENVの記述がLegacy Formatになっていたため修正